### PR TITLE
changed student_id to ManyToOneRel

### DIFF
--- a/capstoneapi/models/grouping.py
+++ b/capstoneapi/models/grouping.py
@@ -6,5 +6,5 @@ from .student import Student
 
 class Grouping(models.Model):
 
-    student_id = models.ForeignKey(Student, on_delete=models.DO_NOTHING)
+    student_id = models.ManyToOneRel(Student, on_delete=models.DO_NOTHING)
     instructor = models.ForeignKey(Employee, on_delete=models.DO_NOTHING)


### PR DESCRIPTION
This PR changes `student_id` in `\capstoneapi\models\grouping.py` from a `ForeignKey` to a `ManyToOneRel`. This is so multiple students can be in one grouping.